### PR TITLE
Add instructions for undefining variables

### DIFF
--- a/markup/lisp
+++ b/markup/lisp
@@ -45,7 +45,7 @@
 ||[#quote quote] _
 @<&nbsp;>@||quote||quote||quote||quote||
 ||[#undefine undefine] _
-@<&nbsp;>@||(makunbound 'foo)||||(ns-unmap *ns* 'foo)||(makunbound 'foo||
+@<&nbsp;>@||(makunbound 'foo)||(namespace-undefine-variable! 'foo)||(ns-unmap *ns* 'foo)||(makunbound 'foo||
 ||[#cell-types cell types] _
 @<&nbsp;>@||##gray|//value, function, struct, class, ...//##||##gray|//value//##||##gray|//value//##||##gray|//value, function, struct, ...//##||
 ||[[# null]][#null-note null]||nil||null||nil||nil||

--- a/markup/lisp
+++ b/markup/lisp
@@ -44,6 +44,8 @@
 @<&nbsp;>@||set,setq,defun||define||def,defn||set,setq,defun||
 ||[#quote quote] _
 @<&nbsp;>@||quote||quote||quote||quote||
+||[#undefine undefine] _
+@<&nbsp;>@||(makunbound 'foo)||||(ns-unmap *ns* 'foo)||(makunbound 'foo||
 ||[#cell-types cell types] _
 @<&nbsp;>@||##gray|//value, function, struct, class, ...//##||##gray|//value//##||##gray|//value//##||##gray|//value, function, struct, ...//##||
 ||[[# null]][#null-note null]||nil||null||nil||nil||


### PR DESCRIPTION
Hey, I was looking for ways to undefine/unintern variables in Lisp. Since I didn't find it in Hyperpolyglot, I added a line describing how to do it (except Racket, for which I was unable to).